### PR TITLE
Fix when user doesn't have contacts

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,10 @@ GoogleContacts.prototype.getContacts = function (cb, params) {
   function receivedContacts(err, data) {
     if (err) return cb(err);
 
+    if(!data.feed.entry) {
+      return cb(null, []);
+    }
+
     self._saveContactsFromFeed(data.feed);
 
     var next = false;


### PR DESCRIPTION
Error when user doesn't have contacts:

``````
/Users/antonio/dev/careerdean/wiselike/node_modules/google-contacts/tests/test.js:12
  if (err) throw err;
           ^

TypeError: Cannot read property 'forEach' of undefined
    at EventEmitter.GoogleContacts._saveContactsFromFeed (/Users/antonio/dev/careerdean/wiselike/node_modules/google-contacts/index.js:125:13)
    at receivedContacts (/Users/antonio/dev/careerdean/wiselike/node_modules/google-contacts/index.js:107:10)
    at IncomingMessage.<anonymous> (/Users/antonio/dev/careerdean/wiselike/node_modules/google-contacts/index.js:89:9)
    at emitNone (events.js:72:20)
    at IncomingMessage.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at doNTCallback2 (node.js:452:9)
    at process._tickCallback (node.js:366:17)```
``````
