### PR TITLE
fix params + adds missing id from getContact test

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ GoogleContacts.prototype._get = function (params, cb) {
 
 GoogleContacts.prototype.getContacts = function (cb, params) {
     var self = this;
-    
+
     this._get(_.extend({type: 'contacts'}, this.params, params), receivedContacts);
     function receivedContacts(err, data) {
         if (err) return cb(err);

--- a/index.js
+++ b/index.js
@@ -96,6 +96,7 @@ GoogleContacts.prototype._get = function (params, cb) {
 
 GoogleContacts.prototype.getContacts = function (cb, params) {
     var self = this;
+    
     this._get(_.extend({type: 'contacts'}, this.params, params), receivedContacts);
     function receivedContacts(err, data) {
         if (err) return cb(err);
@@ -167,8 +168,6 @@ GoogleContacts.prototype._buildPath = function (params) {
     params.projection = params.projection || (params.thin ? 'thin' : 'full');
     params.email = params.email || 'default';
     params['max-results'] = params['max-results'] || 10000;
-
-    console.log('params', params)
 
     var query = {
         alt: params.alt

--- a/index.js
+++ b/index.js
@@ -96,8 +96,7 @@ GoogleContacts.prototype._get = function (params, cb) {
 
 GoogleContacts.prototype.getContacts = function (cb, params) {
     var self = this;
-
-    this._get(_.extend({type: 'contacts'}, params, this.params), receivedContacts);
+    this._get(_.extend({type: 'contacts'}, this.params, params), receivedContacts);
     function receivedContacts(err, data) {
         if (err) return cb(err);
 
@@ -135,7 +134,7 @@ GoogleContacts.prototype.getContact = function (cb, params) {
     function receivedContact(err, contact) {
         if (err) return cb(err);
 
-        cb(null, contact);
+        cb(null, _.get(contact, 'entry', []));
     }
 
 };
@@ -162,12 +161,14 @@ GoogleContacts.prototype._saveContactsFromFeed = function (feed) {
 GoogleContacts.prototype._buildPath = function (params) {
     if (params.path) return params.path;
 
-    params = _.extend({}, params, this.params);
+    params = _.extend({}, this.params, params);
     params.type = params.type || 'contacts';
     params.alt = params.alt || 'json';
     params.projection = params.projection || (params.thin ? 'thin' : 'full');
     params.email = params.email || 'default';
     params['max-results'] = params['max-results'] || 10000;
+
+    console.log('params', params)
 
     var query = {
         alt: params.alt

--- a/tests/test.js
+++ b/tests/test.js
@@ -13,16 +13,25 @@ var c = new GoogleContacts({
 c.getContacts(function (err, contacts) {
   if (err) throw err;
   assert.ok(typeof contacts === 'object', 'Contacts is not an object');
-  console.log(contacts);
+  console.log('Showing first 10 contacts out of '+ contacts.length)
+  console.log(contacts.slice(0,9));
+  // setting first contact as the id for the getContact test
   contactsTested = true;
+  test_id = contacts[0].id
+
+  // this one needs a valid id
+  c.getContact(function (err, contact) {
+    if (err) throw err;
+    assert.ok(typeof contact === 'object', 'Contact is not an object');
+    console.log('Showing individual contact (first from previous test)')
+    console.log(contact);
+    contactTested = true;
+  }, {
+    id: test_id
+  });
 });
 
-c.getContact(function (err, contact) {
-  if (err) throw err;
-  assert.ok(typeof contact === 'object', 'Contact is not an object');
-  console.log(contact);
-  contactTested = true;
-});
+
 
 process.on('exit', function () {
   if (!contactsTested || !contactTested) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -31,8 +31,6 @@ c.getContacts(function (err, contacts) {
   });
 });
 
-
-
 process.on('exit', function () {
   if (!contactsTested || !contactTested) {
     throw new Error('contact test failed');


### PR DESCRIPTION
tests were not running correctly out of the box

`extend` was overwriting the params set by tests/usage